### PR TITLE
fix `get_capability()` params check

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 //!
 pub use crate::kinode::process::standard::*;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 wit_bindgen::generate!({
     path: "kinode-wit",
@@ -206,8 +207,36 @@ pub fn can_message(address: &Address) -> bool {
 /// Get a capability in our store
 /// NOTE unfortunatly this is O(n), not sure if wit let's us do any better
 pub fn get_capability(our: &Address, params: &str) -> Option<Capability> {
+    let params = serde_json::from_str::<Value>(params).unwrap_or_default();
     crate::our_capabilities()
         .iter()
-        .find(|cap| cap.issuer == *our && cap.params == params)
+        .find(|cap| {
+            let cap_params = serde_json::from_str::<Value>(&cap.params).unwrap_or_default();
+            cap.issuer == *our && are_equal_json_values(&params, &cap_params)
+        })
         .cloned()
 }
+
+fn are_equal_json_objects(obj1: &Value, obj2: &Value) -> bool {
+    match (obj1.as_object(), obj2.as_object()) {
+        (Some(map1), Some(map2)) => {
+            if map1.len() != map2.len() {
+                return false;
+            }
+
+            map1.iter().all(|(key, val1)| {
+                map2.get(key)
+                    .map_or(false, |val2| are_equal_json_values(val1, val2))
+            })
+        }
+        _ => false,
+    }
+}
+
+fn are_equal_json_values(val1: &Value, val2: &Value) -> bool {
+    match (val1, val2) {
+        (Value::Object(_), Value::Object(_)) => are_equal_json_objects(val1, val2),
+        _ => val1 == val2,
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,4 +239,3 @@ fn are_equal_json_values(val1: &Value, val2: &Value) -> bool {
         _ => val1 == val2,
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,37 +205,13 @@ pub fn can_message(address: &Address) -> bool {
 }
 
 /// Get a capability in our store
-/// NOTE unfortunatly this is O(n), not sure if wit let's us do any better
 pub fn get_capability(our: &Address, params: &str) -> Option<Capability> {
     let params = serde_json::from_str::<Value>(params).unwrap_or_default();
     crate::our_capabilities()
         .iter()
         .find(|cap| {
             let cap_params = serde_json::from_str::<Value>(&cap.params).unwrap_or_default();
-            cap.issuer == *our && are_equal_json_values(&params, &cap_params)
+            cap.issuer == *our && params == cap_params
         })
         .cloned()
-}
-
-fn are_equal_json_objects(obj1: &Value, obj2: &Value) -> bool {
-    match (obj1.as_object(), obj2.as_object()) {
-        (Some(map1), Some(map2)) => {
-            if map1.len() != map2.len() {
-                return false;
-            }
-
-            map1.iter().all(|(key, val1)| {
-                map2.get(key)
-                    .map_or(false, |val2| are_equal_json_values(val1, val2))
-            })
-        }
-        _ => false,
-    }
-}
-
-fn are_equal_json_values(val1: &Value, val2: &Value) -> bool {
-    match (val1, val2) {
-        (Value::Object(_), Value::Object(_)) => are_equal_json_objects(val1, val2),
-        _ => val1 == val2,
-    }
 }


### PR DESCRIPTION
Because json is unordered, the stored json params could sometimes be a different order than the one checked by the caller. Here, we convert to json and check equality of all fields. This came up in a fork on kinode; likely a different version of serde_json has different behavior wrt keeping/changing order of fields in a json object.

Note that I did not check for this same pattern elsewhere in the code. In general, we MUST NOT rely on the order of fields in a json object.

h/t @drunkplato 